### PR TITLE
Fix Duplicate Error for GoogleId

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -8,8 +8,6 @@ const UserSchema = new mongoose.Schema({
   },
   googleId: {
     type: String,
-    unique: true,
-    sparse: true, // googleId unique if present, otherwise multiple users can have no googleId
     default: null,
   },
   username: {
@@ -30,5 +28,15 @@ const UserSchema = new mongoose.Schema({
     default: null,
   },
 });
+
+UserSchema.index(
+  { googleId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      googleId: { $ne: null },
+    },
+  }
+);
 
 export const UserModel = mongoose.model('User', UserSchema);


### PR DESCRIPTION
### PR DESCRITPION
I have fixed the duplicate error for `googleId`.

- [x] Remove `Sparse` from schema.
- [x] Add `PartialFilterExpression` for googleId field.  

## Closes
Closes #223 