### PR TITLE
Show IPv4 localhost (127.0.0.1) instead of IPv6 (::1) in logs

### DIFF
--- a/backend/src/middleware/logger.js
+++ b/backend/src/middleware/logger.js
@@ -12,9 +12,11 @@ export const logMiddleware = (req, res, next) => {
       duration: duration,
       userId: req.user?._id.toString(),
       clientIp:
-        req.ip ||
-        req.headers['x-forwarded-for'] ||
-        req.connection.remoteAddress,
+        req.ip === '::1'
+          ? '127.0.0.1'
+          : req.ip ||
+            req.headers['x-forwarded-for'] ||
+            req.connection.remoteAddress,
       userAgent: req.headers['user-agent'],
     };
 


### PR DESCRIPTION
For better display of IP, updates the logging middleware to show 127.0.0.1 instead of ::1 when running on localhost


- [x] change ipv6 ::1 to ipv4 127.0.0.1
- [ ] Peer Review

Closes: #287 